### PR TITLE
revert process' stream pipe name to origin

### DIFF
--- a/src/main/kotlin/com/github/nayasis/kotlin/basica/core/io/InputStreams.kt
+++ b/src/main/kotlin/com/github/nayasis/kotlin/basica/core/io/InputStreams.kt
@@ -6,6 +6,9 @@ import java.io.InputStreamReader
 import java.io.OutputStream
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.CopyOption
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * copy contents to given output stream
@@ -67,6 +70,18 @@ fun InputStream.copyTo(out: OutputStream, start: Long, end: Long, bufferSize: In
     }
     return end - start + 1 - remainToCopy
 
+}
+
+/**
+ * copy contents to given target file
+ *
+ * @receiver InputStream
+ * @param target file path
+ * @param option options how the copy should be done
+ * @return written number of bytes
+ */
+fun InputStream.copyTo(target: Path, vararg option: CopyOption): Long {
+    return Files.copy(this, target, *option )
 }
 
 /**

--- a/src/main/kotlin/com/github/nayasis/kotlin/basica/exec/CommandExecutor.kt
+++ b/src/main/kotlin/com/github/nayasis/kotlin/basica/exec/CommandExecutor.kt
@@ -25,43 +25,49 @@ class CommandExecutor {
     var process: Process
         private set
 
-    private var outputGobbler: ProcessOutputThread? = null
-    private var errorGobbler:  ProcessOutputThread? = null
-    private var latch: CountDownLatch? = null
-
-    private var inputPipe: BufferedWriter? = null
+    private var inputGobbler: ProcessOutputThread? = null
+    private var errorGobbler: ProcessOutputThread? = null
+    private var countdownLatch: CountDownLatch? = null
+    private val commandWriter: BufferedWriter
         get() {
-            if(field == null)
-                field = BufferedWriter(OutputStreamWriter(input, Platforms.os.charset))
-            return field
+            if(_writer == null)
+                _writer = BufferedWriter(OutputStreamWriter(outputStream, Platforms.os.charset))
+            return _writer!!
         }
+        private var _writer: BufferedWriter? = null
 
     /**
-     * normal output of process
+     * normal input stream (receiving printed output from process)
      */
-    val output: InputStream
+    val inputStream: InputStream
         get() = process.inputStream
 
     /**
-     * error output of process
+     * error input stream (pipe receiving error from process)
      */
-    val error: InputStream
+    val errorStream: InputStream
         get() = process.errorStream
 
     /**
-     * normal input stream of process
+     * process output stream (pipe sending command to process)
      */
-    val input: OutputStream
+    val outputStream: OutputStream
         get() = process.outputStream
 
     /**
      * run command
      *
      * @param command       command to execute
+     * @param charset       supported character set (default: OS default)
      * @param outputReader  output reader
      * @param errorReader   error reader
      */
-    constructor(command: Command, outputReader: ((String) -> Unit)? = null, errorReader: ((String) -> Unit)? = null) {
+    constructor(
+        command: Command,
+        charset: String = Platforms.os.charset,
+        outputReader: ((String) -> Unit)? = null,
+        errorReader: ((String) -> Unit)? = null,
+    ) {
 
         if(command.isEmpty())
             throw InvalidParameterException("command is empty.")
@@ -85,18 +91,17 @@ class CommandExecutor {
 
         process = builder.start()
 
-        latch = listOfNotNull(outputReader, errorReader).size.let { if(it > 0) CountDownLatch(it) else null }
-
+        countdownLatch = listOfNotNull(outputReader, errorReader).ifNotEmpty { CountDownLatch(it.size) }
         when {
             outputReader != null && errorReader != null -> {
-                outputReader.let { outputGobbler = ProcessOutputThread(output,it,latch!!).apply { start() } }
-                errorReader.let { errorGobbler = ProcessOutputThread(error,it,latch!!).apply { start() } }
+                outputReader.let { inputGobbler = ProcessOutputThread(inputStream,it,countdownLatch,charset).apply { start() } }
+                errorReader.let { errorGobbler = ProcessOutputThread(errorStream,it,countdownLatch,charset).apply { start() } }
             }
             outputReader != null -> {
-                outputReader.let { outputGobbler = ProcessOutputThread(output,it,latch!!).apply { start() } }
+                outputReader.let { inputGobbler = ProcessOutputThread(inputStream,it,countdownLatch,charset).apply { start() } }
             }
             errorReader != null -> {
-                errorReader.let { errorGobbler = ProcessOutputThread(error,it,latch!!).apply { start() } }
+                errorReader.let { errorGobbler = ProcessOutputThread(errorStream,it,countdownLatch,charset).apply { start() } }
             }
         }
 
@@ -105,10 +110,10 @@ class CommandExecutor {
     /**
      * process is alive or not
      */
-    val alive: Boolean
+    val isAlive: Boolean
         get() = when {
             process.isAlive -> true
-            outputGobbler?.isAlive == true -> true
+            inputGobbler?.isAlive == true -> true
             errorGobbler?.isAlive == true -> true
             else -> false
         }
@@ -120,57 +125,53 @@ class CommandExecutor {
      * @return	process termination code ( 0 : success )
      */
     fun waitFor(timeout: Long = -1): Int {
-
         try {
-            process.let {
-                if( timeout < 0) {
-                    it.waitFor()
-                } else {
-                    it.waitFor(timeout,TimeUnit.MILLISECONDS)
-                }
+            if( timeout < 0) {
+                process.waitFor()
+            } else {
+                process.waitFor(timeout,TimeUnit.MILLISECONDS)
             }
-
-            latch?.let {
+            countdownLatch?.let {
                 if(timeout < 0) {
                     it.await()
                 } else {
                     it.await(timeout,TimeUnit.MILLISECONDS)
                 }
             }
-
             return process.exitValue()
         } finally {
             destroy()
         }
-
     }
 
     /**
      * terminate process forcibly.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     fun destroy() {
         runCatching { process.destroyForcibly() };
-        runCatching { outputGobbler?.interrupt() }; outputGobbler = null
+        runCatching { inputGobbler?.interrupt() }; inputGobbler = null
         runCatching { errorGobbler?.interrupt() }; errorGobbler = null
-        runCatching { inputPipe?.close() }; inputPipe = null
-        runCatching { input.close() }
-        runCatching { output.close() }
-        runCatching { error.close() }
-        latch = null
+        runCatching { _writer?.run{
+            commandWriter.close()
+            _writer = null
+        }}
+        runCatching { outputStream.close() }
+        runCatching { inputStream.close() }
+        runCatching { errorStream.close() }
+        countdownLatch = null
     }
 
     /**
      * send command to process
      *
      * @param command command
-     * @return true if command is sent to process.
      */
-    fun sendCommand(command: String): Boolean {
-        return inputPipe?.let {
+    fun sendCommand(command: String) {
+        commandWriter.let {
             it.write(command)
             it.flush()
-            true
-        } ?: false
+        }
     }
 
 }

--- a/src/main/kotlin/com/github/nayasis/kotlin/basica/exec/ProcessOutputThread.kt
+++ b/src/main/kotlin/com/github/nayasis/kotlin/basica/exec/ProcessOutputThread.kt
@@ -1,6 +1,5 @@
 package com.github.nayasis.kotlin.basica.exec
 
-import com.github.nayasis.kotlin.basica.etc.Platforms
 import com.github.nayasis.kotlin.basica.etc.error
 import mu.KotlinLogging
 import java.io.BufferedReader
@@ -11,9 +10,10 @@ import java.util.concurrent.CountDownLatch
 private val logger = KotlinLogging.logger{}
 
 class ProcessOutputThread(
-    val inputStream: InputStream,
+    private val inputStream: InputStream,
     private val reader: ((String) -> Unit)?,
-    private val latch: CountDownLatch,
+    private val countDownLatch: CountDownLatch?,
+    private val charset: String,
 ): Thread() {
 
     init {
@@ -21,13 +21,13 @@ class ProcessOutputThread(
     }
 
     override fun run() {
-        inputStream.use { InputStreamReader(it, Platforms.os.charset).use { stream -> BufferedReader(stream).use { reader ->
+        inputStream.use { InputStreamReader(it, charset).use { stream -> BufferedReader(stream).use { reader ->
             try {
                 read(reader)
             } catch (e: Exception) {
                 logger.error(e)
             } finally {
-                latch.countDown()
+                countDownLatch?.countDown()
             }
         }}}
     }


### PR DESCRIPTION
1. revert process' stream pipe name to origin because used ones could confuse with other libraries.
2. add extension function [InputStream.copyTo]